### PR TITLE
validate price of limit order and fail if negative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [306](https://github.com/vegaprotocol/protos/pull/306) - Add initial v2 orders API
 
 ### 🐛 Fixes
-- [](https://github.com/vegaprotocol/protos/pull/) -
+- [308](https://github.com/vegaprotocol/protos/pull/308) - Validate order price and fail if not positive
 
 
 ## 0.48.0

--- a/commands/order_submission.go
+++ b/commands/order_submission.go
@@ -182,9 +182,9 @@ func checkOrderSubmission(cmd *commandspb.OrderSubmission) Errors {
 				errs.AddForProperty("order_submission.price", ErrNotAValidInteger)
 			}
 
-			if price.Cmp(big.NewInt(0)) == 0 {
+			if price.Cmp(big.NewInt(0)) != 1 {
 				errs.AddForProperty("order_submission.price",
-					errors.New("is required when the order is of type LIMIT"),
+					errors.New("must be positive when the order is of type LIMIT"),
 				)
 			}
 		}

--- a/commands/order_submission_test.go
+++ b/commands/order_submission_test.go
@@ -28,6 +28,7 @@ func TestCheckOrderSubmission(t *testing.T) {
 	t.Run("Submitting an order with MARKET type and price fails", testOrderSubmissionWithMarketTypeAndPriceFails)
 	t.Run("Submitting an order with MARKET type and wrong time in force fails", testOrderSubmissionWithMarketTypeAndWrongTimeInForceFails)
 	t.Run("Submitting an order with LIMIT type and no price fails", testOrderSubmissionWithLimitTypeAndNoPriceFails)
+	t.Run("Submitting an order with LIMIT type and negative price fails", testOrderSubmissionWithLimitTypeAndNegativePriceFails)
 	t.Run("Submitting a pegged order with LIMIT type and no price succeeds", testPeggedOrderSubmissionWithLimitTypeAndNoPriceSucceeds)
 	t.Run("Submitting a pegged order with undefined time in force fails", testPeggedOrderSubmissionWithUndefinedReferenceFails)
 	t.Run("Submitting a pegged order with unspecified time in force fails", testPeggedOrderSubmissionWithUnspecifiedReferenceFails)
@@ -240,6 +241,15 @@ func testOrderSubmissionWithLimitTypeAndNoPriceFails(t *testing.T) {
 	})
 
 	assert.Contains(t, err.Get("order_submission.price"), errors.New("is required when the order is of type LIMIT"))
+}
+
+func testOrderSubmissionWithLimitTypeAndNegativePriceFails(t *testing.T) {
+	err := checkOrderSubmission(&commandspb.OrderSubmission{
+		Type:  types.Order_TYPE_LIMIT,
+		Price: "-1000",
+	})
+
+	assert.Contains(t, err.Get("order_submission.price"), errors.New("must be positive when the order is of type LIMIT"))
 }
 
 func testPeggedOrderSubmissionWithLimitTypeAndNoPriceSucceeds(t *testing.T) {


### PR DESCRIPTION
closes #300 

Tested locally when built into vega:
```
wwestgarth@wwestgarth-macbook ~/work/sample-api-scripts -  (master) $ python3 submit-order/submit-order.py
Traceback (most recent call last):
  File "submit-order/submit-order.py", line 128, in <module>
    helpers.check_response(response)
  File "/Users/wwestgarth/work/sample-api-scripts/helpers.py", line 10, in check_response
    ), f"{r.url} returned HTTP {r.status_code} {r.text}"
AssertionError: http://localhost:1789/api/v1/command/sync returned HTTP 500 {"error":"rpc error: code = Internal desc = Internal error","details":["order_submission.price (must be positive when the order is of type LIMIT)"]}
```