### PR TITLE
fix: make oracle spec ids deterministic across all machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [345](https://github.com/vegaprotocol/protos/issues/345) - Added proof of work to transaction
 
 ### 🐛 Fixes
-- [](https://github.com/vegaprotocol/protos/pull/) -
+- [357](https://github.com/vegaprotocol/protos/issues/357) - make oracle spec ids deterministic across all machines
 
 
 ## 0.49.2

--- a/vega/oracles/v1/spec.go
+++ b/vega/oracles/v1/spec.go
@@ -20,7 +20,12 @@ func NewOracleSpec(pubKeys []string, filters []*Filter) *OracleSpec {
 func newID(pubKeys []string, filters []*Filter) string {
 	buf := []byte{}
 	for _, filter := range filters {
-		buf = append(buf, []byte(filter.String())...)
+		s := filter.Key.Name + filter.Key.Type.String()
+		for _, c := range filter.Conditions {
+			s += c.Operator.String() + c.Value
+		}
+
+		buf = append(buf, []byte(s)...)
 	}
 	buf = append(buf, []byte(strings.Join(pubKeys, ""))...)
 

--- a/vega/oracles/v1/spec_test.go
+++ b/vega/oracles/v1/spec_test.go
@@ -1,0 +1,24 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeterminisitcOracleID(t *testing.T) {
+	filter := &Filter{
+		Key: &PropertyKey{
+			Name: "trading.terminated",
+			Type: PropertyKey_TYPE_BOOLEAN,
+		},
+		Conditions: []*Condition{
+			{
+				Operator: Condition_OPERATOR_EQUALS,
+				Value:    "17",
+			},
+		},
+	}
+	os := NewOracleSpec([]string{"0xDEADBEEF"}, []*Filter{filter})
+	assert.Equal(t, "2fd2f1fbcb2d9ecc102524b6ef48b189ed020eb1fecb613f35ad20471a0e9a96", os.Id)
+}


### PR DESCRIPTION
closes #357 