### PR TITLE
Rename String() method

### DIFF
--- a/commands/delegate_submission.go
+++ b/commands/delegate_submission.go
@@ -47,7 +47,7 @@ func checkUndelegateSubmission(cmd *commandspb.UndelegateSubmission) Errors {
 		return errs.FinalAddForProperty("undelegate_submission", ErrIsRequired)
 	}
 
-	if _, ok := commandspb.UndelegateSubmission_Method_value[cmd.Method.String()]; !ok || cmd.Method == commandspb.UndelegateSubmission_METHOD_UNSPECIFIED {
+	if _, ok := commandspb.UndelegateSubmission_Method_value[cmd.Method.NonDeterministicString()]; !ok || cmd.Method == commandspb.UndelegateSubmission_METHOD_UNSPECIFIED {
 		errs.AddForProperty("undelegate_submission.method", ErrIsRequired)
 	}
 

--- a/script/generate.sh
+++ b/script/generate.sh
@@ -20,13 +20,19 @@ function gen_code() {
 	# Make *.validator.pb.go files deterministic.
 	find vega -name '*.validator.pb.go' | sort | while read -r pbfile
 	do
-        sed -i -re 's/this\.Size_/this.Size/' "$pbfile" \
+        sed -i "" -re 's/this\.Size_/this.Size/' "$pbfile" \
 		&& ./script/fix_imports.sh "$pbfile"
 	done
 	find data-node -name '*.validator.pb.go' | sort | while read -r pbfile
 	do
-        sed -i -re 's/this\.Size_/this.Size/' "$pbfile" \
+        sed -i "" -re 's/this\.Size_/this.Size/' "$pbfile" \
 		&& ./script/fix_imports.sh "$pbfile"
+	done
+
+	find vega -name '*.go' | sort | while read -r pbfile
+	do
+       sed -i "" -e "s/\.String()/.NonDeterministicString()/g" "$pbfile"
+       sed -i "" -e "s/ String()/ NonDeterministicString()/g" "$pbfile"
 	done
 }
 

--- a/vega/api/v1/core.pb.go
+++ b/vega/api/v1/core.pb.go
@@ -60,7 +60,7 @@ func (x SubmitTransactionRequest_Type) Enum() *SubmitTransactionRequest_Type {
 	return p
 }
 
-func (x SubmitTransactionRequest_Type) String() string {
+func (x SubmitTransactionRequest_Type) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -118,7 +118,7 @@ func (x SubmitRawTransactionRequest_Type) Enum() *SubmitRawTransactionRequest_Ty
 	return p
 }
 
-func (x SubmitRawTransactionRequest_Type) String() string {
+func (x SubmitRawTransactionRequest_Type) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -162,7 +162,7 @@ func (x *PropagateChainEventRequest) Reset() {
 	}
 }
 
-func (x *PropagateChainEventRequest) String() string {
+func (x *PropagateChainEventRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -226,7 +226,7 @@ func (x *PropagateChainEventResponse) Reset() {
 	}
 }
 
-func (x *PropagateChainEventResponse) String() string {
+func (x *PropagateChainEventResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -277,7 +277,7 @@ func (x *SubmitTransactionRequest) Reset() {
 	}
 }
 
-func (x *SubmitTransactionRequest) String() string {
+func (x *SubmitTransactionRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -343,7 +343,7 @@ func (x *SubmitTransactionResponse) Reset() {
 	}
 }
 
-func (x *SubmitTransactionResponse) String() string {
+func (x *SubmitTransactionResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -427,7 +427,7 @@ func (x *CheckTransactionRequest) Reset() {
 	}
 }
 
-func (x *CheckTransactionRequest) String() string {
+func (x *CheckTransactionRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -481,7 +481,7 @@ func (x *CheckTransactionResponse) Reset() {
 	}
 }
 
-func (x *CheckTransactionResponse) String() string {
+func (x *CheckTransactionResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -553,7 +553,7 @@ func (x *SubmitRawTransactionRequest) Reset() {
 	}
 }
 
-func (x *SubmitRawTransactionRequest) String() string {
+func (x *SubmitRawTransactionRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -616,7 +616,7 @@ func (x *SubmitRawTransactionResponse) Reset() {
 	}
 }
 
-func (x *SubmitRawTransactionResponse) String() string {
+func (x *SubmitRawTransactionResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -700,7 +700,7 @@ func (x *CheckRawTransactionRequest) Reset() {
 	}
 }
 
-func (x *CheckRawTransactionRequest) String() string {
+func (x *CheckRawTransactionRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -755,7 +755,7 @@ func (x *CheckRawTransactionResponse) Reset() {
 	}
 }
 
-func (x *CheckRawTransactionResponse) String() string {
+func (x *CheckRawTransactionResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -822,7 +822,7 @@ func (x *GetVegaTimeRequest) Reset() {
 	}
 }
 
-func (x *GetVegaTimeRequest) String() string {
+func (x *GetVegaTimeRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -865,7 +865,7 @@ func (x *GetVegaTimeResponse) Reset() {
 	}
 }
 
-func (x *GetVegaTimeResponse) String() string {
+func (x *GetVegaTimeResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -926,7 +926,7 @@ func (x *ObserveEventBusRequest) Reset() {
 	}
 }
 
-func (x *ObserveEventBusRequest) String() string {
+func (x *ObserveEventBusRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -996,7 +996,7 @@ func (x *ObserveEventBusResponse) Reset() {
 	}
 }
 
-func (x *ObserveEventBusResponse) String() string {
+func (x *ObserveEventBusResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1042,7 +1042,7 @@ func (x *StatisticsRequest) Reset() {
 	}
 }
 
-func (x *StatisticsRequest) String() string {
+func (x *StatisticsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1082,7 +1082,7 @@ func (x *StatisticsResponse) Reset() {
 	}
 }
 
-func (x *StatisticsResponse) String() string {
+func (x *StatisticsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1196,7 +1196,7 @@ func (x *Statistics) Reset() {
 	}
 }
 
-func (x *Statistics) String() string {
+func (x *Statistics) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1467,7 +1467,7 @@ func (x *LastBlockHeightRequest) Reset() {
 	}
 }
 
-func (x *LastBlockHeightRequest) String() string {
+func (x *LastBlockHeightRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1522,7 +1522,7 @@ func (x *LastBlockHeightResponse) Reset() {
 	}
 }
 
-func (x *LastBlockHeightResponse) String() string {
+func (x *LastBlockHeightResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/api/v1/corestate.pb.go
+++ b/vega/api/v1/corestate.pb.go
@@ -43,7 +43,7 @@ func (x *Account) Reset() {
 	}
 }
 
-func (x *Account) String() string {
+func (x *Account) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -119,7 +119,7 @@ func (x *ListAccountsRequest) Reset() {
 	}
 }
 
-func (x *ListAccountsRequest) String() string {
+func (x *ListAccountsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -173,7 +173,7 @@ func (x *ListAccountsResponse) Reset() {
 	}
 }
 
-func (x *ListAccountsResponse) String() string {
+func (x *ListAccountsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -220,7 +220,7 @@ func (x *ListAssetsRequest) Reset() {
 	}
 }
 
-func (x *ListAssetsRequest) String() string {
+func (x *ListAssetsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -267,7 +267,7 @@ func (x *ListAssetsResponse) Reset() {
 	}
 }
 
-func (x *ListAssetsResponse) String() string {
+func (x *ListAssetsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -314,7 +314,7 @@ func (x *ListNetworkParametersRequest) Reset() {
 	}
 }
 
-func (x *ListNetworkParametersRequest) String() string {
+func (x *ListNetworkParametersRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -361,7 +361,7 @@ func (x *ListNetworkParametersResponse) Reset() {
 	}
 }
 
-func (x *ListNetworkParametersResponse) String() string {
+func (x *ListNetworkParametersResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -406,7 +406,7 @@ func (x *ListNetworkLimitsRequest) Reset() {
 	}
 }
 
-func (x *ListNetworkLimitsRequest) String() string {
+func (x *ListNetworkLimitsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -446,7 +446,7 @@ func (x *ListNetworkLimitsResponse) Reset() {
 	}
 }
 
-func (x *ListNetworkLimitsResponse) String() string {
+func (x *ListNetworkLimitsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -491,7 +491,7 @@ func (x *ListPartiesRequest) Reset() {
 	}
 }
 
-func (x *ListPartiesRequest) String() string {
+func (x *ListPartiesRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -531,7 +531,7 @@ func (x *ListPartiesResponse) Reset() {
 	}
 }
 
-func (x *ListPartiesResponse) String() string {
+func (x *ListPartiesResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -576,7 +576,7 @@ func (x *ListValidatorsRequest) Reset() {
 	}
 }
 
-func (x *ListValidatorsRequest) String() string {
+func (x *ListValidatorsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -616,7 +616,7 @@ func (x *ListValidatorsResponse) Reset() {
 	}
 }
 
-func (x *ListValidatorsResponse) String() string {
+func (x *ListValidatorsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -663,7 +663,7 @@ func (x *ListMarketsRequest) Reset() {
 	}
 }
 
-func (x *ListMarketsRequest) String() string {
+func (x *ListMarketsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -710,7 +710,7 @@ func (x *ListMarketsResponse) Reset() {
 	}
 }
 
-func (x *ListMarketsResponse) String() string {
+func (x *ListMarketsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -758,7 +758,7 @@ func (x *ListProposalsRequest) Reset() {
 	}
 }
 
-func (x *ListProposalsRequest) String() string {
+func (x *ListProposalsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -812,7 +812,7 @@ func (x *ListProposalsResponse) Reset() {
 	}
 }
 
-func (x *ListProposalsResponse) String() string {
+func (x *ListProposalsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -859,7 +859,7 @@ func (x *ListMarketsDataRequest) Reset() {
 	}
 }
 
-func (x *ListMarketsDataRequest) String() string {
+func (x *ListMarketsDataRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -906,7 +906,7 @@ func (x *ListMarketsDataResponse) Reset() {
 	}
 }
 
-func (x *ListMarketsDataResponse) String() string {
+func (x *ListMarketsDataResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -954,7 +954,7 @@ func (x *ListVotesRequest) Reset() {
 	}
 }
 
-func (x *ListVotesRequest) String() string {
+func (x *ListVotesRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1008,7 +1008,7 @@ func (x *ListVotesResponse) Reset() {
 	}
 }
 
-func (x *ListVotesResponse) String() string {
+func (x *ListVotesResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1057,7 +1057,7 @@ func (x *PartyStake) Reset() {
 	}
 }
 
-func (x *PartyStake) String() string {
+func (x *PartyStake) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1118,7 +1118,7 @@ func (x *ListPartiesStakeRequest) Reset() {
 	}
 }
 
-func (x *ListPartiesStakeRequest) String() string {
+func (x *ListPartiesStakeRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1165,7 +1165,7 @@ func (x *ListPartiesStakeResponse) Reset() {
 	}
 }
 
-func (x *ListPartiesStakeResponse) String() string {
+func (x *ListPartiesStakeResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1214,7 +1214,7 @@ func (x *ListDelegationsRequest) Reset() {
 	}
 }
 
-func (x *ListDelegationsRequest) String() string {
+func (x *ListDelegationsRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1275,7 +1275,7 @@ func (x *ListDelegationsResponse) Reset() {
 	}
 }
 
-func (x *ListDelegationsResponse) String() string {
+func (x *ListDelegationsResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/assets.pb.go
+++ b/vega/assets.pb.go
@@ -41,7 +41,7 @@ func (x *Asset) Reset() {
 	}
 }
 
-func (x *Asset) String() string {
+func (x *Asset) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -111,7 +111,7 @@ func (x *AssetDetails) Reset() {
 	}
 }
 
-func (x *AssetDetails) String() string {
+func (x *AssetDetails) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -227,7 +227,7 @@ func (x *BuiltinAsset) Reset() {
 	}
 }
 
-func (x *BuiltinAsset) String() string {
+func (x *BuiltinAsset) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -276,7 +276,7 @@ func (x *ERC20) Reset() {
 	}
 }
 
-func (x *ERC20) String() string {
+func (x *ERC20) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/chain_events.pb.go
+++ b/vega/chain_events.pb.go
@@ -43,7 +43,7 @@ func (x *BuiltinAssetDeposit) Reset() {
 	}
 }
 
-func (x *BuiltinAssetDeposit) String() string {
+func (x *BuiltinAssetDeposit) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -110,7 +110,7 @@ func (x *BuiltinAssetWithdrawal) Reset() {
 	}
 }
 
-func (x *BuiltinAssetWithdrawal) String() string {
+func (x *BuiltinAssetWithdrawal) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -175,7 +175,7 @@ func (x *BuiltinAssetEvent) Reset() {
 	}
 }
 
-func (x *BuiltinAssetEvent) String() string {
+func (x *BuiltinAssetEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -256,7 +256,7 @@ func (x *ERC20AssetList) Reset() {
 	}
 }
 
-func (x *ERC20AssetList) String() string {
+func (x *ERC20AssetList) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -305,7 +305,7 @@ func (x *ERC20AssetDelist) Reset() {
 	}
 }
 
-func (x *ERC20AssetDelist) String() string {
+func (x *ERC20AssetDelist) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -360,7 +360,7 @@ func (x *ERC20Deposit) Reset() {
 	}
 }
 
-func (x *ERC20Deposit) String() string {
+func (x *ERC20Deposit) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -434,7 +434,7 @@ func (x *ERC20Withdrawal) Reset() {
 	}
 }
 
-func (x *ERC20Withdrawal) String() string {
+func (x *ERC20Withdrawal) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -507,7 +507,7 @@ func (x *ERC20Event) Reset() {
 	}
 }
 
-func (x *ERC20Event) String() string {
+func (x *ERC20Event) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -636,7 +636,7 @@ func (x *ERC20SignerAdded) Reset() {
 	}
 }
 
-func (x *ERC20SignerAdded) String() string {
+func (x *ERC20SignerAdded) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -705,7 +705,7 @@ func (x *ERC20SignerRemoved) Reset() {
 	}
 }
 
-func (x *ERC20SignerRemoved) String() string {
+func (x *ERC20SignerRemoved) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -774,7 +774,7 @@ func (x *ERC20ThresholdSet) Reset() {
 	}
 }
 
-func (x *ERC20ThresholdSet) String() string {
+func (x *ERC20ThresholdSet) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -846,7 +846,7 @@ func (x *ERC20MultiSigEvent) Reset() {
 	}
 }
 
-func (x *ERC20MultiSigEvent) String() string {
+func (x *ERC20MultiSigEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -961,7 +961,7 @@ func (x *StakingEvent) Reset() {
 	}
 }
 
-func (x *StakingEvent) String() string {
+func (x *StakingEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1074,7 +1074,7 @@ func (x *StakeDeposited) Reset() {
 	}
 }
 
-func (x *StakeDeposited) String() string {
+func (x *StakeDeposited) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1151,7 +1151,7 @@ func (x *StakeRemoved) Reset() {
 	}
 }
 
-func (x *StakeRemoved) String() string {
+func (x *StakeRemoved) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1222,7 +1222,7 @@ func (x *StakeTotalSupply) Reset() {
 	}
 }
 
-func (x *StakeTotalSupply) String() string {
+func (x *StakeTotalSupply) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/checkpoint/v1/checkpoint.pb.go
+++ b/vega/checkpoint/v1/checkpoint.pb.go
@@ -41,7 +41,7 @@ func (x *CheckpointState) Reset() {
 	}
 }
 
-func (x *CheckpointState) String() string {
+func (x *CheckpointState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -107,7 +107,7 @@ func (x *Checkpoint) Reset() {
 	}
 }
 
-func (x *Checkpoint) String() string {
+func (x *Checkpoint) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -233,7 +233,7 @@ func (x *AssetEntry) Reset() {
 	}
 }
 
-func (x *AssetEntry) String() string {
+func (x *AssetEntry) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -288,7 +288,7 @@ func (x *Assets) Reset() {
 	}
 }
 
-func (x *Assets) String() string {
+func (x *Assets) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -338,7 +338,7 @@ func (x *AssetBalance) Reset() {
 	}
 }
 
-func (x *AssetBalance) String() string {
+func (x *AssetBalance) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -400,7 +400,7 @@ func (x *Collateral) Reset() {
 	}
 }
 
-func (x *Collateral) String() string {
+func (x *Collateral) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -448,7 +448,7 @@ func (x *NetParams) Reset() {
 	}
 }
 
-func (x *NetParams) String() string {
+func (x *NetParams) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -496,7 +496,7 @@ func (x *Proposals) Reset() {
 	}
 }
 
-func (x *Proposals) String() string {
+func (x *Proposals) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -549,7 +549,7 @@ func (x *DelegateEntry) Reset() {
 	}
 }
 
-func (x *DelegateEntry) String() string {
+func (x *DelegateEntry) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -627,7 +627,7 @@ func (x *Delegate) Reset() {
 	}
 }
 
-func (x *Delegate) String() string {
+func (x *Delegate) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -690,7 +690,7 @@ func (x *Block) Reset() {
 	}
 }
 
-func (x *Block) String() string {
+func (x *Block) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -737,7 +737,7 @@ func (x *Rewards) Reset() {
 	}
 }
 
-func (x *Rewards) String() string {
+func (x *Rewards) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -785,7 +785,7 @@ func (x *RewardPayout) Reset() {
 	}
 }
 
-func (x *RewardPayout) String() string {
+func (x *RewardPayout) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -844,7 +844,7 @@ func (x *PendingRewardPayout) Reset() {
 	}
 }
 
-func (x *PendingRewardPayout) String() string {
+func (x *PendingRewardPayout) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -927,7 +927,7 @@ func (x *PartyAmount) Reset() {
 	}
 }
 
-func (x *PartyAmount) String() string {
+func (x *PartyAmount) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -986,7 +986,7 @@ func (x *PendingKeyRotation) Reset() {
 	}
 }
 
-func (x *PendingKeyRotation) String() string {
+func (x *PendingKeyRotation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1058,7 +1058,7 @@ func (x *PendingEthereumKeyRotation) Reset() {
 	}
 }
 
-func (x *PendingEthereumKeyRotation) String() string {
+func (x *PendingEthereumKeyRotation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1122,7 +1122,7 @@ func (x *ScheduledTransfer) Reset() {
 	}
 }
 
-func (x *ScheduledTransfer) String() string {
+func (x *ScheduledTransfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1191,7 +1191,7 @@ func (x *ScheduledTransferAtTime) Reset() {
 	}
 }
 
-func (x *ScheduledTransferAtTime) String() string {
+func (x *ScheduledTransferAtTime) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1245,7 +1245,7 @@ func (x *RecurringTransfers) Reset() {
 	}
 }
 
-func (x *RecurringTransfers) String() string {
+func (x *RecurringTransfers) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1293,7 +1293,7 @@ func (x *Banking) Reset() {
 	}
 }
 
-func (x *Banking) String() string {
+func (x *Banking) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1349,7 +1349,7 @@ func (x *Validators) Reset() {
 	}
 }
 
-func (x *Validators) String() string {
+func (x *Validators) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1414,7 +1414,7 @@ func (x *ValidatorState) Reset() {
 	}
 }
 
-func (x *ValidatorState) String() string {
+func (x *ValidatorState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1490,7 +1490,7 @@ func (x *Staking) Reset() {
 	}
 }
 
-func (x *Staking) String() string {
+func (x *Staking) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1546,7 +1546,7 @@ func (x *MultisigControl) Reset() {
 	}
 }
 
-func (x *MultisigControl) String() string {
+func (x *MultisigControl) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/commands/v1/commands.pb.go
+++ b/vega/commands/v1/commands.pb.go
@@ -52,7 +52,7 @@ func (x UndelegateSubmission_Method) Enum() *UndelegateSubmission_Method {
 	return p
 }
 
-func (x UndelegateSubmission_Method) String() string {
+func (x UndelegateSubmission_Method) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -92,7 +92,7 @@ func (x *Int64Value) Reset() {
 	}
 }
 
-func (x *Int64Value) String() string {
+func (x *Int64Value) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -165,7 +165,7 @@ func (x *OrderSubmission) Reset() {
 	}
 }
 
-func (x *OrderSubmission) String() string {
+func (x *OrderSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -272,7 +272,7 @@ func (x *OrderCancellation) Reset() {
 	}
 }
 
-func (x *OrderCancellation) String() string {
+func (x *OrderCancellation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -348,7 +348,7 @@ func (x *OrderAmendment) Reset() {
 	}
 }
 
-func (x *OrderAmendment) String() string {
+func (x *OrderAmendment) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -456,7 +456,7 @@ func (x *LiquidityProvisionSubmission) Reset() {
 	}
 }
 
-func (x *LiquidityProvisionSubmission) String() string {
+func (x *LiquidityProvisionSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -539,7 +539,7 @@ func (x *LiquidityProvisionCancellation) Reset() {
 	}
 }
 
-func (x *LiquidityProvisionCancellation) String() string {
+func (x *LiquidityProvisionCancellation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -593,7 +593,7 @@ func (x *LiquidityProvisionAmendment) Reset() {
 	}
 }
 
-func (x *LiquidityProvisionAmendment) String() string {
+func (x *LiquidityProvisionAmendment) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -681,7 +681,7 @@ func (x *WithdrawSubmission) Reset() {
 	}
 }
 
-func (x *WithdrawSubmission) String() string {
+func (x *WithdrawSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -747,7 +747,7 @@ func (x *ProposalSubmission) Reset() {
 	}
 }
 
-func (x *ProposalSubmission) String() string {
+func (x *ProposalSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -806,7 +806,7 @@ func (x *VoteSubmission) Reset() {
 	}
 }
 
-func (x *VoteSubmission) String() string {
+func (x *VoteSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -864,7 +864,7 @@ func (x *DelegateSubmission) Reset() {
 	}
 }
 
-func (x *DelegateSubmission) String() string {
+func (x *DelegateSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -921,7 +921,7 @@ func (x *UndelegateSubmission) Reset() {
 	}
 }
 
-func (x *UndelegateSubmission) String() string {
+func (x *UndelegateSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -983,7 +983,7 @@ func (x *RestoreSnapshot) Reset() {
 	}
 }
 
-func (x *RestoreSnapshot) String() string {
+func (x *RestoreSnapshot) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1049,7 +1049,7 @@ func (x *Transfer) Reset() {
 	}
 }
 
-func (x *Transfer) String() string {
+func (x *Transfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1171,7 +1171,7 @@ func (x *OneOffTransfer) Reset() {
 	}
 }
 
-func (x *OneOffTransfer) String() string {
+func (x *OneOffTransfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1224,7 +1224,7 @@ func (x *RecurringTransfer) Reset() {
 	}
 }
 
-func (x *RecurringTransfer) String() string {
+func (x *RecurringTransfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1287,7 +1287,7 @@ func (x *CancelTransfer) Reset() {
 	}
 }
 
-func (x *CancelTransfer) String() string {
+func (x *CancelTransfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/commands/v1/oracles.pb.go
+++ b/vega/commands/v1/oracles.pb.go
@@ -52,7 +52,7 @@ func (x OracleDataSubmission_OracleSource) Enum() *OracleDataSubmission_OracleSo
 	return p
 }
 
-func (x OracleDataSubmission_OracleSource) String() string {
+func (x OracleDataSubmission_OracleSource) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -94,7 +94,7 @@ func (x *OracleDataSubmission) Reset() {
 	}
 }
 
-func (x *OracleDataSubmission) String() string {
+func (x *OracleDataSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/commands/v1/signature.pb.go
+++ b/vega/commands/v1/signature.pb.go
@@ -44,7 +44,7 @@ func (x *Signature) Reset() {
 	}
 }
 
-func (x *Signature) String() string {
+func (x *Signature) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/commands/v1/transaction.pb.go
+++ b/vega/commands/v1/transaction.pb.go
@@ -81,7 +81,7 @@ func (x *InputData) Reset() {
 	}
 }
 
-func (x *InputData) String() string {
+func (x *InputData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -465,7 +465,7 @@ func (x *Transaction) Reset() {
 	}
 }
 
-func (x *Transaction) String() string {
+func (x *Transaction) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -574,7 +574,7 @@ func (x *ProofOfWork) Reset() {
 	}
 }
 
-func (x *ProofOfWork) String() string {
+func (x *ProofOfWork) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/commands/v1/validator_commands.pb.go
+++ b/vega/commands/v1/validator_commands.pb.go
@@ -61,7 +61,7 @@ func (x NodeSignatureKind) Enum() *NodeSignatureKind {
 	return p
 }
 
-func (x NodeSignatureKind) String() string {
+func (x NodeSignatureKind) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -106,7 +106,7 @@ func (x *ValidatorHeartbeat) Reset() {
 	}
 }
 
-func (x *ValidatorHeartbeat) String() string {
+func (x *ValidatorHeartbeat) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -192,7 +192,7 @@ func (x *AnnounceNode) Reset() {
 	}
 }
 
-func (x *AnnounceNode) String() string {
+func (x *AnnounceNode) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -319,7 +319,7 @@ func (x *NodeVote) Reset() {
 	}
 }
 
-func (x *NodeVote) String() string {
+func (x *NodeVote) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -372,7 +372,7 @@ func (x *NodeSignature) Reset() {
 	}
 }
 
-func (x *NodeSignature) String() string {
+func (x *NodeSignature) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -445,7 +445,7 @@ func (x *ChainEvent) Reset() {
 	}
 }
 
-func (x *ChainEvent) String() string {
+func (x *ChainEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -574,7 +574,7 @@ func (x *KeyRotateSubmission) Reset() {
 	}
 }
 
-func (x *KeyRotateSubmission) String() string {
+func (x *KeyRotateSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -648,7 +648,7 @@ func (x *EthereumKeyRotateSubmission) Reset() {
 	}
 }
 
-func (x *EthereumKeyRotateSubmission) String() string {
+func (x *EthereumKeyRotateSubmission) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -710,7 +710,7 @@ func (x *StateVariableProposal) Reset() {
 	}
 }
 
-func (x *StateVariableProposal) String() string {
+func (x *StateVariableProposal) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/events/v1/events.pb.go
+++ b/vega/events/v1/events.pb.go
@@ -246,7 +246,7 @@ func (x BusEventType) Enum() *BusEventType {
 	return p
 }
 
-func (x BusEventType) String() string {
+func (x BusEventType) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -311,7 +311,7 @@ func (x Transfer_Status) Enum() *Transfer_Status {
 	return p
 }
 
-func (x Transfer_Status) String() string {
+func (x Transfer_Status) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -363,7 +363,7 @@ func (x StakeLinking_Type) Enum() *StakeLinking_Type {
 	return p
 }
 
-func (x StakeLinking_Type) String() string {
+func (x StakeLinking_Type) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -419,7 +419,7 @@ func (x StakeLinking_Status) Enum() *StakeLinking_Status {
 	return p
 }
 
-func (x StakeLinking_Status) String() string {
+func (x StakeLinking_Status) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -468,7 +468,7 @@ func (x ERC20MultiSigSignerEvent_Type) Enum() *ERC20MultiSigSignerEvent_Type {
 	return p
 }
 
-func (x ERC20MultiSigSignerEvent_Type) String() string {
+func (x ERC20MultiSigSignerEvent_Type) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -517,7 +517,7 @@ func (x *ERC20MultiSigSignerAdded) Reset() {
 	}
 }
 
-func (x *ERC20MultiSigSignerAdded) String() string {
+func (x *ERC20MultiSigSignerAdded) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -602,7 +602,7 @@ func (x *ERC20MulistSigSignerRemovedSubmitter) Reset() {
 	}
 }
 
-func (x *ERC20MulistSigSignerRemovedSubmitter) String() string {
+func (x *ERC20MulistSigSignerRemovedSubmitter) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -667,7 +667,7 @@ func (x *ERC20MultiSigSignerRemoved) Reset() {
 	}
 }
 
-func (x *ERC20MultiSigSignerRemoved) String() string {
+func (x *ERC20MultiSigSignerRemoved) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -755,7 +755,7 @@ func (x *Transfer) Reset() {
 	}
 }
 
-func (x *Transfer) String() string {
+func (x *Transfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -902,7 +902,7 @@ func (x *OneOffTransfer) Reset() {
 	}
 }
 
-func (x *OneOffTransfer) String() string {
+func (x *OneOffTransfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -951,7 +951,7 @@ func (x *RecurringTransfer) Reset() {
 	}
 }
 
-func (x *RecurringTransfer) String() string {
+func (x *RecurringTransfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1037,7 +1037,7 @@ func (x *StakeLinking) Reset() {
 	}
 }
 
-func (x *StakeLinking) String() string {
+func (x *StakeLinking) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1168,7 +1168,7 @@ func (x *ERC20MultiSigSignerEvent) Reset() {
 	}
 }
 
-func (x *ERC20MultiSigSignerEvent) String() string {
+func (x *ERC20MultiSigSignerEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1270,7 +1270,7 @@ func (x *ERC20MultiSigThresholdSetEvent) Reset() {
 	}
 }
 
-func (x *ERC20MultiSigThresholdSetEvent) String() string {
+func (x *ERC20MultiSigThresholdSetEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1361,7 +1361,7 @@ func (x *CheckpointEvent) Reset() {
 	}
 }
 
-func (x *CheckpointEvent) String() string {
+func (x *CheckpointEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1422,7 +1422,7 @@ func (x *StreamStartEvent) Reset() {
 	}
 }
 
-func (x *StreamStartEvent) String() string {
+func (x *StreamStartEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1474,7 +1474,7 @@ func (x *RewardPayoutEvent) Reset() {
 	}
 }
 
-func (x *RewardPayoutEvent) String() string {
+func (x *RewardPayoutEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1564,7 +1564,7 @@ func (x *ValidatorScoreEvent) Reset() {
 	}
 }
 
-func (x *ValidatorScoreEvent) String() string {
+func (x *ValidatorScoreEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1664,7 +1664,7 @@ func (x *DelegationBalanceEvent) Reset() {
 	}
 }
 
-func (x *DelegationBalanceEvent) String() string {
+func (x *DelegationBalanceEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1737,7 +1737,7 @@ func (x *MarketEvent) Reset() {
 	}
 }
 
-func (x *MarketEvent) String() string {
+func (x *MarketEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1814,7 +1814,7 @@ func (x *TxErrorEvent) Reset() {
 	}
 }
 
-func (x *TxErrorEvent) String() string {
+func (x *TxErrorEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2089,7 +2089,7 @@ func (x *TimeUpdate) Reset() {
 	}
 }
 
-func (x *TimeUpdate) String() string {
+func (x *TimeUpdate) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2146,7 +2146,7 @@ func (x *EpochEvent) Reset() {
 	}
 }
 
-func (x *EpochEvent) String() string {
+func (x *EpochEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2223,7 +2223,7 @@ func (x *TransferResponses) Reset() {
 	}
 }
 
-func (x *TransferResponses) String() string {
+func (x *TransferResponses) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2278,7 +2278,7 @@ func (x *PositionResolution) Reset() {
 	}
 }
 
-func (x *PositionResolution) String() string {
+func (x *PositionResolution) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2352,7 +2352,7 @@ func (x *LossSocialization) Reset() {
 	}
 }
 
-func (x *LossSocialization) String() string {
+func (x *LossSocialization) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2417,7 +2417,7 @@ func (x *TradeSettlement) Reset() {
 	}
 }
 
-func (x *TradeSettlement) String() string {
+func (x *TradeSettlement) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2481,7 +2481,7 @@ func (x *SettlePosition) Reset() {
 	}
 }
 
-func (x *SettlePosition) String() string {
+func (x *SettlePosition) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2568,7 +2568,7 @@ func (x *PositionStateEvent) Reset() {
 	}
 }
 
-func (x *PositionStateEvent) String() string {
+func (x *PositionStateEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2667,7 +2667,7 @@ func (x *SettleDistressed) Reset() {
 	}
 }
 
-func (x *SettleDistressed) String() string {
+func (x *SettleDistressed) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2739,7 +2739,7 @@ func (x *MarketTick) Reset() {
 	}
 }
 
-func (x *MarketTick) String() string {
+func (x *MarketTick) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2808,7 +2808,7 @@ func (x *AuctionEvent) Reset() {
 	}
 }
 
-func (x *AuctionEvent) String() string {
+func (x *AuctionEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2919,7 +2919,7 @@ func (x *ValidatorUpdate) Reset() {
 	}
 }
 
-func (x *ValidatorUpdate) String() string {
+func (x *ValidatorUpdate) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3051,7 +3051,7 @@ func (x *ValidatorRankingEvent) Reset() {
 	}
 }
 
-func (x *ValidatorRankingEvent) String() string {
+func (x *ValidatorRankingEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3155,7 +3155,7 @@ func (x *KeyRotation) Reset() {
 	}
 }
 
-func (x *KeyRotation) String() string {
+func (x *KeyRotation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3231,7 +3231,7 @@ func (x *EthereumKeyRotation) Reset() {
 	}
 }
 
-func (x *EthereumKeyRotation) String() string {
+func (x *EthereumKeyRotation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3302,7 +3302,7 @@ func (x *StateVar) Reset() {
 	}
 }
 
-func (x *StateVar) String() string {
+func (x *StateVar) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3422,7 +3422,7 @@ func (x *BusEvent) Reset() {
 	}
 }
 
-func (x *BusEvent) String() string {
+func (x *BusEvent) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/governance.pb.go
+++ b/vega/governance.pb.go
@@ -198,7 +198,7 @@ func (x ProposalError) Enum() *ProposalError {
 	return p
 }
 
-func (x ProposalError) String() string {
+func (x ProposalError) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -277,7 +277,7 @@ func (x Proposal_State) Enum() *Proposal_State {
 	return p
 }
 
-func (x Proposal_State) String() string {
+func (x Proposal_State) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -330,7 +330,7 @@ func (x Vote_Value) Enum() *Vote_Value {
 	return p
 }
 
-func (x Vote_Value) String() string {
+func (x Vote_Value) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -378,7 +378,7 @@ func (x *FutureProduct) Reset() {
 	}
 }
 
-func (x *FutureProduct) String() string {
+func (x *FutureProduct) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -462,7 +462,7 @@ func (x *InstrumentConfiguration) Reset() {
 	}
 }
 
-func (x *InstrumentConfiguration) String() string {
+func (x *InstrumentConfiguration) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -559,7 +559,7 @@ func (x *NewMarketConfiguration) Reset() {
 	}
 }
 
-func (x *NewMarketConfiguration) String() string {
+func (x *NewMarketConfiguration) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -690,7 +690,7 @@ func (x *NewMarketCommitment) Reset() {
 	}
 }
 
-func (x *NewMarketCommitment) String() string {
+func (x *NewMarketCommitment) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -769,7 +769,7 @@ func (x *NewMarket) Reset() {
 	}
 }
 
-func (x *NewMarket) String() string {
+func (x *NewMarket) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -827,7 +827,7 @@ func (x *UpdateMarket) Reset() {
 	}
 }
 
-func (x *UpdateMarket) String() string {
+func (x *UpdateMarket) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -895,7 +895,7 @@ func (x *UpdateMarketConfiguration) Reset() {
 	}
 }
 
-func (x *UpdateMarketConfiguration) String() string {
+func (x *UpdateMarketConfiguration) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1009,7 +1009,7 @@ func (x *UpdateInstrumentConfiguration) Reset() {
 	}
 }
 
-func (x *UpdateInstrumentConfiguration) String() string {
+func (x *UpdateInstrumentConfiguration) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1089,7 +1089,7 @@ func (x *UpdateFutureProduct) Reset() {
 	}
 }
 
-func (x *UpdateFutureProduct) String() string {
+func (x *UpdateFutureProduct) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1159,7 +1159,7 @@ func (x *UpdateNetworkParameter) Reset() {
 	}
 }
 
-func (x *UpdateNetworkParameter) String() string {
+func (x *UpdateNetworkParameter) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1208,7 +1208,7 @@ func (x *NewAsset) Reset() {
 	}
 }
 
-func (x *NewAsset) String() string {
+func (x *NewAsset) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1260,7 +1260,7 @@ func (x *NewFreeformDetails) Reset() {
 	}
 }
 
-func (x *NewFreeformDetails) String() string {
+func (x *NewFreeformDetails) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1323,7 +1323,7 @@ func (x *NewFreeform) Reset() {
 	}
 }
 
-func (x *NewFreeform) String() string {
+func (x *NewFreeform) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1387,7 +1387,7 @@ func (x *ProposalTerms) Reset() {
 	}
 }
 
-func (x *ProposalTerms) String() string {
+func (x *ProposalTerms) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1543,7 +1543,7 @@ func (x *GovernanceData) Reset() {
 	}
 }
 
-func (x *GovernanceData) String() string {
+func (x *GovernanceData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1634,7 +1634,7 @@ func (x *Proposal) Reset() {
 	}
 }
 
-func (x *Proposal) String() string {
+func (x *Proposal) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1744,7 +1744,7 @@ func (x *Vote) Reset() {
 	}
 }
 
-func (x *Vote) String() string {
+func (x *Vote) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/markets.pb.go
+++ b/vega/markets.pb.go
@@ -83,7 +83,7 @@ func (x Market_State) Enum() *Market_State {
 	return p
 }
 
-func (x Market_State) String() string {
+func (x Market_State) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -144,7 +144,7 @@ func (x Market_TradingMode) Enum() *Market_TradingMode {
 	return p
 }
 
-func (x Market_TradingMode) String() string {
+func (x Market_TradingMode) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -192,7 +192,7 @@ func (x *AuctionDuration) Reset() {
 	}
 }
 
-func (x *AuctionDuration) String() string {
+func (x *AuctionDuration) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -258,7 +258,7 @@ func (x *Future) Reset() {
 	}
 }
 
-func (x *Future) String() string {
+func (x *Future) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -348,7 +348,7 @@ func (x *OracleSpecToFutureBinding) Reset() {
 	}
 }
 
-func (x *OracleSpecToFutureBinding) String() string {
+func (x *OracleSpecToFutureBinding) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -404,7 +404,7 @@ func (x *InstrumentMetadata) Reset() {
 	}
 }
 
-func (x *InstrumentMetadata) String() string {
+func (x *InstrumentMetadata) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -464,7 +464,7 @@ func (x *Instrument) Reset() {
 	}
 }
 
-func (x *Instrument) String() string {
+func (x *Instrument) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -563,7 +563,7 @@ func (x *LogNormalRiskModel) Reset() {
 	}
 }
 
-func (x *LogNormalRiskModel) String() string {
+func (x *LogNormalRiskModel) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -630,7 +630,7 @@ func (x *LogNormalModelParams) Reset() {
 	}
 }
 
-func (x *LogNormalModelParams) String() string {
+func (x *LogNormalModelParams) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -693,7 +693,7 @@ func (x *SimpleRiskModel) Reset() {
 	}
 }
 
-func (x *SimpleRiskModel) String() string {
+func (x *SimpleRiskModel) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -750,7 +750,7 @@ func (x *SimpleModelParams) Reset() {
 	}
 }
 
-func (x *SimpleModelParams) String() string {
+func (x *SimpleModelParams) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -831,7 +831,7 @@ func (x *ScalingFactors) Reset() {
 	}
 }
 
-func (x *ScalingFactors) String() string {
+func (x *ScalingFactors) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -894,7 +894,7 @@ func (x *MarginCalculator) Reset() {
 	}
 }
 
-func (x *MarginCalculator) String() string {
+func (x *MarginCalculator) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -951,7 +951,7 @@ func (x *TradableInstrument) Reset() {
 	}
 }
 
-func (x *TradableInstrument) String() string {
+func (x *TradableInstrument) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1050,7 +1050,7 @@ func (x *FeeFactors) Reset() {
 	}
 }
 
-func (x *FeeFactors) String() string {
+func (x *FeeFactors) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1113,7 +1113,7 @@ func (x *Fees) Reset() {
 	}
 }
 
-func (x *Fees) String() string {
+func (x *Fees) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1168,7 +1168,7 @@ func (x *PriceMonitoringTrigger) Reset() {
 	}
 }
 
-func (x *PriceMonitoringTrigger) String() string {
+func (x *PriceMonitoringTrigger) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1230,7 +1230,7 @@ func (x *PriceMonitoringParameters) Reset() {
 	}
 }
 
-func (x *PriceMonitoringParameters) String() string {
+func (x *PriceMonitoringParameters) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1281,7 +1281,7 @@ func (x *PriceMonitoringSettings) Reset() {
 	}
 }
 
-func (x *PriceMonitoringSettings) String() string {
+func (x *PriceMonitoringSettings) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1341,7 +1341,7 @@ func (x *LiquidityMonitoringParameters) Reset() {
 	}
 }
 
-func (x *LiquidityMonitoringParameters) String() string {
+func (x *LiquidityMonitoringParameters) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1406,7 +1406,7 @@ func (x *TargetStakeParameters) Reset() {
 	}
 }
 
-func (x *TargetStakeParameters) String() string {
+func (x *TargetStakeParameters) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1485,7 +1485,7 @@ func (x *Market) Reset() {
 	}
 }
 
-func (x *Market) String() string {
+func (x *Market) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1610,7 +1610,7 @@ func (x *MarketTimestamps) Reset() {
 	}
 }
 
-func (x *MarketTimestamps) String() string {
+func (x *MarketTimestamps) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/oracles/v1/data.pb.go
+++ b/vega/oracles/v1/data.pb.go
@@ -48,7 +48,7 @@ func (x *OracleData) Reset() {
 	}
 }
 
-func (x *OracleData) String() string {
+func (x *OracleData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -120,7 +120,7 @@ func (x *Property) Reset() {
 	}
 }
 
-func (x *Property) String() string {
+func (x *Property) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/oracles/v1/spec.go
+++ b/vega/oracles/v1/spec.go
@@ -20,9 +20,9 @@ func NewOracleSpec(pubKeys []string, filters []*Filter) *OracleSpec {
 func newID(pubKeys []string, filters []*Filter) string {
 	buf := []byte{}
 	for _, filter := range filters {
-		s := filter.Key.Name + filter.Key.Type.String()
+		s := filter.Key.Name + filter.Key.Type.NonDeterministicString()
 		for _, c := range filter.Conditions {
-			s += c.Operator.String() + c.Value
+			s += c.Operator.NonDeterministicString() + c.Value
 		}
 
 		buf = append(buf, []byte(s)...)

--- a/vega/oracles/v1/spec.pb.go
+++ b/vega/oracles/v1/spec.pb.go
@@ -53,7 +53,7 @@ func (x OracleSpec_Status) Enum() *OracleSpec_Status {
 	return p
 }
 
-func (x OracleSpec_Status) String() string {
+func (x OracleSpec_Status) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -123,7 +123,7 @@ func (x PropertyKey_Type) Enum() *PropertyKey_Type {
 	return p
 }
 
-func (x PropertyKey_Type) String() string {
+func (x PropertyKey_Type) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -190,7 +190,7 @@ func (x Condition_Operator) Enum() *Condition_Operator {
 	return p
 }
 
-func (x Condition_Operator) String() string {
+func (x Condition_Operator) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -236,7 +236,7 @@ func (x *OracleSpecConfiguration) Reset() {
 	}
 }
 
-func (x *OracleSpecConfiguration) String() string {
+func (x *OracleSpecConfiguration) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -307,7 +307,7 @@ func (x *OracleSpec) Reset() {
 	}
 }
 
-func (x *OracleSpec) String() string {
+func (x *OracleSpec) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -395,7 +395,7 @@ func (x *Filter) Reset() {
 	}
 }
 
-func (x *Filter) String() string {
+func (x *Filter) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -453,7 +453,7 @@ func (x *PropertyKey) Reset() {
 	}
 }
 
-func (x *PropertyKey) String() string {
+func (x *PropertyKey) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -511,7 +511,7 @@ func (x *Condition) Reset() {
 	}
 }
 
-func (x *Condition) String() string {
+func (x *Condition) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/snapshot/v1/snapshot.pb.go
+++ b/vega/snapshot/v1/snapshot.pb.go
@@ -59,7 +59,7 @@ func (x Format) Enum() *Format {
 	return p
 }
 
-func (x Format) String() string {
+func (x Format) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -101,7 +101,7 @@ func (x *Snapshot) Reset() {
 	}
 }
 
-func (x *Snapshot) String() string {
+func (x *Snapshot) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -187,7 +187,7 @@ func (x *NodeHash) Reset() {
 	}
 }
 
-func (x *NodeHash) String() string {
+func (x *NodeHash) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -264,7 +264,7 @@ func (x *Metadata) Reset() {
 	}
 }
 
-func (x *Metadata) String() string {
+func (x *Metadata) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -329,7 +329,7 @@ func (x *Chunk) Reset() {
 	}
 }
 
-func (x *Chunk) String() string {
+func (x *Chunk) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -442,7 +442,7 @@ func (x *Payload) Reset() {
 	}
 }
 
-func (x *Payload) String() string {
+func (x *Payload) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1157,7 +1157,7 @@ func (x *TimestampedOpenInterest) Reset() {
 	}
 }
 
-func (x *TimestampedOpenInterest) String() string {
+func (x *TimestampedOpenInterest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1216,7 +1216,7 @@ func (x *LiquidityTarget) Reset() {
 	}
 }
 
-func (x *LiquidityTarget) String() string {
+func (x *LiquidityTarget) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1299,7 +1299,7 @@ func (x *LiquidityPriceProbabilityPair) Reset() {
 	}
 }
 
-func (x *LiquidityPriceProbabilityPair) String() string {
+func (x *LiquidityPriceProbabilityPair) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1356,7 +1356,7 @@ func (x *LiquiditySupplied) Reset() {
 	}
 }
 
-func (x *LiquiditySupplied) String() string {
+func (x *LiquiditySupplied) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1424,7 +1424,7 @@ func (x *OracleDataBatch) Reset() {
 	}
 }
 
-func (x *OracleDataBatch) String() string {
+func (x *OracleDataBatch) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1472,7 +1472,7 @@ func (x *OracleData) Reset() {
 	}
 }
 
-func (x *OracleData) String() string {
+func (x *OracleData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1527,7 +1527,7 @@ func (x *OracleDataPair) Reset() {
 	}
 }
 
-func (x *OracleDataPair) String() string {
+func (x *OracleDataPair) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1582,7 +1582,7 @@ func (x *Witness) Reset() {
 	}
 }
 
-func (x *Witness) String() string {
+func (x *Witness) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1639,7 +1639,7 @@ func (x *Resource) Reset() {
 	}
 }
 
-func (x *Resource) String() string {
+func (x *Resource) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1707,7 +1707,7 @@ func (x *EventForwarder) Reset() {
 	}
 }
 
-func (x *EventForwarder) String() string {
+func (x *EventForwarder) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1754,7 +1754,7 @@ func (x *CollateralAccounts) Reset() {
 	}
 }
 
-func (x *CollateralAccounts) String() string {
+func (x *CollateralAccounts) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1801,7 +1801,7 @@ func (x *CollateralAssets) Reset() {
 	}
 }
 
-func (x *CollateralAssets) String() string {
+func (x *CollateralAssets) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1848,7 +1848,7 @@ func (x *ActiveAssets) Reset() {
 	}
 }
 
-func (x *ActiveAssets) String() string {
+func (x *ActiveAssets) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1895,7 +1895,7 @@ func (x *PendingAssets) Reset() {
 	}
 }
 
-func (x *PendingAssets) String() string {
+func (x *PendingAssets) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1943,7 +1943,7 @@ func (x *Withdrawal) Reset() {
 	}
 }
 
-func (x *Withdrawal) String() string {
+func (x *Withdrawal) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1998,7 +1998,7 @@ func (x *Deposit) Reset() {
 	}
 }
 
-func (x *Deposit) String() string {
+func (x *Deposit) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2055,7 +2055,7 @@ func (x *TxRef) Reset() {
 	}
 }
 
-func (x *TxRef) String() string {
+func (x *TxRef) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2131,7 +2131,7 @@ func (x *AssetAction) Reset() {
 	}
 }
 
-func (x *AssetAction) String() string {
+func (x *AssetAction) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2234,7 +2234,7 @@ func (x *BankingWithdrawals) Reset() {
 	}
 }
 
-func (x *BankingWithdrawals) String() string {
+func (x *BankingWithdrawals) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2281,7 +2281,7 @@ func (x *BankingDeposits) Reset() {
 	}
 }
 
-func (x *BankingDeposits) String() string {
+func (x *BankingDeposits) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2328,7 +2328,7 @@ func (x *BankingSeen) Reset() {
 	}
 }
 
-func (x *BankingSeen) String() string {
+func (x *BankingSeen) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2375,7 +2375,7 @@ func (x *BankingAssetActions) Reset() {
 	}
 }
 
-func (x *BankingAssetActions) String() string {
+func (x *BankingAssetActions) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2422,7 +2422,7 @@ func (x *BankingRecurringTransfers) Reset() {
 	}
 }
 
-func (x *BankingRecurringTransfers) String() string {
+func (x *BankingRecurringTransfers) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2469,7 +2469,7 @@ func (x *BankingScheduledTransfers) Reset() {
 	}
 }
 
-func (x *BankingScheduledTransfers) String() string {
+func (x *BankingScheduledTransfers) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2516,7 +2516,7 @@ func (x *Checkpoint) Reset() {
 	}
 }
 
-func (x *Checkpoint) String() string {
+func (x *Checkpoint) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2563,7 +2563,7 @@ func (x *DelegationLastReconciliationTime) Reset() {
 	}
 }
 
-func (x *DelegationLastReconciliationTime) String() string {
+func (x *DelegationLastReconciliationTime) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2610,7 +2610,7 @@ func (x *DelegationActive) Reset() {
 	}
 }
 
-func (x *DelegationActive) String() string {
+func (x *DelegationActive) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2658,7 +2658,7 @@ func (x *DelegationPending) Reset() {
 	}
 }
 
-func (x *DelegationPending) String() string {
+func (x *DelegationPending) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2712,7 +2712,7 @@ func (x *DelegationAuto) Reset() {
 	}
 }
 
-func (x *DelegationAuto) String() string {
+func (x *DelegationAuto) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2762,7 +2762,7 @@ func (x *ProposalData) Reset() {
 	}
 }
 
-func (x *ProposalData) String() string {
+func (x *ProposalData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2830,7 +2830,7 @@ func (x *GovernanceEnacted) Reset() {
 	}
 }
 
-func (x *GovernanceEnacted) String() string {
+func (x *GovernanceEnacted) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2877,7 +2877,7 @@ func (x *GovernanceActive) Reset() {
 	}
 }
 
-func (x *GovernanceActive) String() string {
+func (x *GovernanceActive) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2924,7 +2924,7 @@ func (x *GovernanceNode) Reset() {
 	}
 }
 
-func (x *GovernanceNode) String() string {
+func (x *GovernanceNode) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2973,7 +2973,7 @@ func (x *StakingAccount) Reset() {
 	}
 }
 
-func (x *StakingAccount) String() string {
+func (x *StakingAccount) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3035,7 +3035,7 @@ func (x *StakingAccounts) Reset() {
 	}
 }
 
-func (x *StakingAccounts) String() string {
+func (x *StakingAccounts) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3094,7 +3094,7 @@ func (x *MatchingBook) Reset() {
 	}
 }
 
-func (x *MatchingBook) String() string {
+func (x *MatchingBook) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3176,7 +3176,7 @@ func (x *NetParams) Reset() {
 	}
 }
 
-func (x *NetParams) String() string {
+func (x *NetParams) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3224,7 +3224,7 @@ func (x *DecimalMap) Reset() {
 	}
 }
 
-func (x *DecimalMap) String() string {
+func (x *DecimalMap) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3279,7 +3279,7 @@ func (x *TimePrice) Reset() {
 	}
 }
 
-func (x *TimePrice) String() string {
+func (x *TimePrice) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3334,7 +3334,7 @@ func (x *PriceVolume) Reset() {
 	}
 }
 
-func (x *PriceVolume) String() string {
+func (x *PriceVolume) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3390,7 +3390,7 @@ func (x *PriceRange) Reset() {
 	}
 }
 
-func (x *PriceRange) String() string {
+func (x *PriceRange) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3454,7 +3454,7 @@ func (x *PriceBound) Reset() {
 	}
 }
 
-func (x *PriceBound) String() string {
+func (x *PriceBound) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3523,7 +3523,7 @@ func (x *PriceRangeCache) Reset() {
 	}
 }
 
-func (x *PriceRangeCache) String() string {
+func (x *PriceRangeCache) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3578,7 +3578,7 @@ func (x *CurrentPrice) Reset() {
 	}
 }
 
-func (x *CurrentPrice) String() string {
+func (x *CurrentPrice) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3633,7 +3633,7 @@ func (x *PastPrice) Reset() {
 	}
 }
 
-func (x *PastPrice) String() string {
+func (x *PastPrice) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3698,7 +3698,7 @@ func (x *PriceMonitor) Reset() {
 	}
 }
 
-func (x *PriceMonitor) String() string {
+func (x *PriceMonitor) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3829,7 +3829,7 @@ func (x *AuctionState) Reset() {
 	}
 }
 
-func (x *AuctionState) String() string {
+func (x *AuctionState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3928,7 +3928,7 @@ func (x *EquityShareLP) Reset() {
 	}
 }
 
-func (x *EquityShareLP) String() string {
+func (x *EquityShareLP) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3998,7 +3998,7 @@ func (x *EquityShare) Reset() {
 	}
 }
 
-func (x *EquityShare) String() string {
+func (x *EquityShare) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4060,7 +4060,7 @@ func (x *FeeSplitter) Reset() {
 	}
 }
 
-func (x *FeeSplitter) String() string {
+func (x *FeeSplitter) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4130,7 +4130,7 @@ func (x *Market) Reset() {
 	}
 }
 
-func (x *Market) String() string {
+func (x *Market) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4289,7 +4289,7 @@ func (x *ExecutionMarkets) Reset() {
 	}
 }
 
-func (x *ExecutionMarkets) String() string {
+func (x *ExecutionMarkets) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4342,7 +4342,7 @@ func (x *Position) Reset() {
 	}
 }
 
-func (x *Position) String() string {
+func (x *Position) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4432,7 +4432,7 @@ func (x *MarketPositions) Reset() {
 	}
 }
 
-func (x *MarketPositions) String() string {
+func (x *MarketPositions) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4489,7 +4489,7 @@ func (x *AppState) Reset() {
 	}
 }
 
-func (x *AppState) String() string {
+func (x *AppState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4567,7 +4567,7 @@ func (x *EpochState) Reset() {
 	}
 }
 
-func (x *EpochState) String() string {
+func (x *EpochState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4642,7 +4642,7 @@ func (x *RewardsPendingPayouts) Reset() {
 	}
 }
 
-func (x *RewardsPendingPayouts) String() string {
+func (x *RewardsPendingPayouts) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4690,7 +4690,7 @@ func (x *ScheduledRewardsPayout) Reset() {
 	}
 }
 
-func (x *ScheduledRewardsPayout) String() string {
+func (x *ScheduledRewardsPayout) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4749,7 +4749,7 @@ func (x *RewardsPayout) Reset() {
 	}
 }
 
-func (x *RewardsPayout) String() string {
+func (x *RewardsPayout) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4832,7 +4832,7 @@ func (x *RewardsPartyAmount) Reset() {
 	}
 }
 
-func (x *RewardsPartyAmount) String() string {
+func (x *RewardsPartyAmount) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4899,7 +4899,7 @@ func (x *LimitState) Reset() {
 	}
 }
 
-func (x *LimitState) String() string {
+func (x *LimitState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5002,7 +5002,7 @@ func (x *VoteSpamPolicy) Reset() {
 	}
 }
 
-func (x *VoteSpamPolicy) String() string {
+func (x *VoteSpamPolicy) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5100,7 +5100,7 @@ func (x *PartyProposalVoteCount) Reset() {
 	}
 }
 
-func (x *PartyProposalVoteCount) String() string {
+func (x *PartyProposalVoteCount) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5162,7 +5162,7 @@ func (x *BannedParty) Reset() {
 	}
 }
 
-func (x *BannedParty) String() string {
+func (x *BannedParty) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5217,7 +5217,7 @@ func (x *PartyTokenBalance) Reset() {
 	}
 }
 
-func (x *PartyTokenBalance) String() string {
+func (x *PartyTokenBalance) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5272,7 +5272,7 @@ func (x *BlockRejectStats) Reset() {
 	}
 }
 
-func (x *BlockRejectStats) String() string {
+func (x *BlockRejectStats) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5327,7 +5327,7 @@ func (x *SpamPartyTransactionCount) Reset() {
 	}
 }
 
-func (x *SpamPartyTransactionCount) String() string {
+func (x *SpamPartyTransactionCount) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5385,7 +5385,7 @@ func (x *SimpleSpamPolicy) Reset() {
 	}
 }
 
-func (x *SimpleSpamPolicy) String() string {
+func (x *SimpleSpamPolicy) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5463,7 +5463,7 @@ func (x *NotarySigs) Reset() {
 	}
 }
 
-func (x *NotarySigs) String() string {
+func (x *NotarySigs) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5531,7 +5531,7 @@ func (x *Notary) Reset() {
 	}
 }
 
-func (x *Notary) String() string {
+func (x *Notary) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5580,7 +5580,7 @@ func (x *ReplayProtection) Reset() {
 	}
 }
 
-func (x *ReplayProtection) String() string {
+func (x *ReplayProtection) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5642,7 +5642,7 @@ func (x *TransactionAtHeight) Reset() {
 	}
 }
 
-func (x *TransactionAtHeight) String() string {
+func (x *TransactionAtHeight) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5698,7 +5698,7 @@ func (x *FutureState) Reset() {
 	}
 }
 
-func (x *FutureState) String() string {
+func (x *FutureState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5759,7 +5759,7 @@ func (x *StakeVerifierDeposited) Reset() {
 	}
 }
 
-func (x *StakeVerifierDeposited) String() string {
+func (x *StakeVerifierDeposited) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5806,7 +5806,7 @@ func (x *StakeVerifierRemoved) Reset() {
 	}
 }
 
-func (x *StakeVerifierRemoved) String() string {
+func (x *StakeVerifierRemoved) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5860,7 +5860,7 @@ func (x *StakeVerifierPending) Reset() {
 	}
 }
 
-func (x *StakeVerifierPending) String() string {
+func (x *StakeVerifierPending) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5959,7 +5959,7 @@ func (x *PendingKeyRotation) Reset() {
 	}
 }
 
-func (x *PendingKeyRotation) String() string {
+func (x *PendingKeyRotation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6029,7 +6029,7 @@ func (x *PendingEthereumKeyRotation) Reset() {
 	}
 }
 
-func (x *PendingEthereumKeyRotation) String() string {
+func (x *PendingEthereumKeyRotation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6094,7 +6094,7 @@ func (x *Topology) Reset() {
 	}
 }
 
-func (x *Topology) String() string {
+func (x *Topology) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6177,7 +6177,7 @@ func (x *ValidatorState) Reset() {
 	}
 }
 
-func (x *ValidatorState) String() string {
+func (x *ValidatorState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6283,7 +6283,7 @@ func (x *HeartbeatTracker) Reset() {
 	}
 }
 
-func (x *HeartbeatTracker) String() string {
+func (x *HeartbeatTracker) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6357,7 +6357,7 @@ func (x *PerformanceStats) Reset() {
 	}
 }
 
-func (x *PerformanceStats) String() string {
+func (x *PerformanceStats) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6446,7 +6446,7 @@ func (x *ValidatorPerformance) Reset() {
 	}
 }
 
-func (x *ValidatorPerformance) String() string {
+func (x *ValidatorPerformance) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6497,7 +6497,7 @@ func (x *LiquidityParameters) Reset() {
 	}
 }
 
-func (x *LiquidityParameters) String() string {
+func (x *LiquidityParameters) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6567,7 +6567,7 @@ func (x *LiquidityPendingProvisions) Reset() {
 	}
 }
 
-func (x *LiquidityPendingProvisions) String() string {
+func (x *LiquidityPendingProvisions) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6623,7 +6623,7 @@ func (x *LiquidityPartiesLiquidityOrders) Reset() {
 	}
 }
 
-func (x *LiquidityPartiesLiquidityOrders) String() string {
+func (x *LiquidityPartiesLiquidityOrders) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6679,7 +6679,7 @@ func (x *LiquidityPartiesOrders) Reset() {
 	}
 }
 
-func (x *LiquidityPartiesOrders) String() string {
+func (x *LiquidityPartiesOrders) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6735,7 +6735,7 @@ func (x *LiquidityProvisions) Reset() {
 	}
 }
 
-func (x *LiquidityProvisions) String() string {
+func (x *LiquidityProvisions) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6790,7 +6790,7 @@ func (x *FloatingPointConsensus) Reset() {
 	}
 }
 
-func (x *FloatingPointConsensus) String() string {
+func (x *FloatingPointConsensus) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6840,7 +6840,7 @@ func (x *NextTimeTrigger) Reset() {
 	}
 }
 
-func (x *NextTimeTrigger) String() string {
+func (x *NextTimeTrigger) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6908,7 +6908,7 @@ func (x *FeesTracker) Reset() {
 	}
 }
 
-func (x *FeesTracker) String() string {
+func (x *FeesTracker) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6958,7 +6958,7 @@ func (x *AssetFees) Reset() {
 	}
 }
 
-func (x *AssetFees) String() string {
+func (x *AssetFees) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7027,7 +7027,7 @@ func (x *PartyFees) Reset() {
 	}
 }
 
-func (x *PartyFees) String() string {
+func (x *PartyFees) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7081,7 +7081,7 @@ func (x *MarketTracker) Reset() {
 	}
 }
 
-func (x *MarketTracker) String() string {
+func (x *MarketTracker) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7131,7 +7131,7 @@ func (x *MarketVolumeTracker) Reset() {
 	}
 }
 
-func (x *MarketVolumeTracker) String() string {
+func (x *MarketVolumeTracker) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7200,7 +7200,7 @@ func (x *SignerEventsPerAddress) Reset() {
 	}
 }
 
-func (x *SignerEventsPerAddress) String() string {
+func (x *SignerEventsPerAddress) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7257,7 +7257,7 @@ func (x *ERC20MultiSigTopologyVerified) Reset() {
 	}
 }
 
-func (x *ERC20MultiSigTopologyVerified) String() string {
+func (x *ERC20MultiSigTopologyVerified) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7328,7 +7328,7 @@ func (x *ERC20MultiSigTopologyPending) Reset() {
 	}
 }
 
-func (x *ERC20MultiSigTopologyPending) String() string {
+func (x *ERC20MultiSigTopologyPending) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7402,7 +7402,7 @@ func (x *ProofOfWork) Reset() {
 	}
 }
 
-func (x *ProofOfWork) String() string {
+func (x *ProofOfWork) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -7492,7 +7492,7 @@ func (x *TransactionsAtHeight) Reset() {
 	}
 }
 
-func (x *TransactionsAtHeight) String() string {
+func (x *TransactionsAtHeight) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/vega.pb.go
+++ b/vega/vega.pb.go
@@ -52,7 +52,7 @@ func (x Side) Enum() *Side {
 	return p
 }
 
-func (x Side) String() string {
+func (x Side) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -121,7 +121,7 @@ func (x Interval) Enum() *Interval {
 	return p
 }
 
-func (x Interval) String() string {
+func (x Interval) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -182,7 +182,7 @@ func (x AuctionTrigger) Enum() *AuctionTrigger {
 	return p
 }
 
-func (x AuctionTrigger) String() string {
+func (x AuctionTrigger) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -240,7 +240,7 @@ func (x PeggedReference) Enum() *PeggedReference {
 	return p
 }
 
-func (x PeggedReference) String() string {
+func (x PeggedReference) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -469,7 +469,7 @@ func (x OrderError) Enum() *OrderError {
 	return p
 }
 
-func (x OrderError) String() string {
+func (x OrderError) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -526,7 +526,7 @@ func (x ChainStatus) Enum() *ChainStatus {
 	return p
 }
 
-func (x ChainStatus) String() string {
+func (x ChainStatus) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -649,7 +649,7 @@ func (x AccountType) Enum() *AccountType {
 	return p
 }
 
-func (x AccountType) String() string {
+func (x AccountType) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -786,7 +786,7 @@ func (x TransferType) Enum() *TransferType {
 	return p
 }
 
-func (x TransferType) String() string {
+func (x TransferType) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -838,7 +838,7 @@ func (x NodeStatus) Enum() *NodeStatus {
 	return p
 }
 
-func (x NodeStatus) String() string {
+func (x NodeStatus) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -890,7 +890,7 @@ func (x EpochAction) Enum() *EpochAction {
 	return p
 }
 
-func (x EpochAction) String() string {
+func (x EpochAction) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -946,7 +946,7 @@ func (x ValidatorNodeStatus) Enum() *ValidatorNodeStatus {
 	return p
 }
 
-func (x ValidatorNodeStatus) String() string {
+func (x ValidatorNodeStatus) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1016,7 +1016,7 @@ func (x Order_TimeInForce) Enum() *Order_TimeInForce {
 	return p
 }
 
-func (x Order_TimeInForce) String() string {
+func (x Order_TimeInForce) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1073,7 +1073,7 @@ func (x Order_Type) Enum() *Order_Type {
 	return p
 }
 
-func (x Order_Type) String() string {
+func (x Order_Type) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1151,7 +1151,7 @@ func (x Order_Status) Enum() *Order_Status {
 	return p
 }
 
-func (x Order_Status) String() string {
+func (x Order_Status) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1210,7 +1210,7 @@ func (x Trade_Type) Enum() *Trade_Type {
 	return p
 }
 
-func (x Trade_Type) String() string {
+func (x Trade_Type) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1267,7 +1267,7 @@ func (x Deposit_Status) Enum() *Deposit_Status {
 	return p
 }
 
-func (x Deposit_Status) String() string {
+func (x Deposit_Status) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1325,7 +1325,7 @@ func (x Withdrawal_Status) Enum() *Withdrawal_Status {
 	return p
 }
 
-func (x Withdrawal_Status) String() string {
+func (x Withdrawal_Status) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1396,7 +1396,7 @@ func (x LiquidityProvision_Status) Enum() *LiquidityProvision_Status {
 	return p
 }
 
-func (x LiquidityProvision_Status) String() string {
+func (x LiquidityProvision_Status) NonDeterministicString() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
@@ -1436,7 +1436,7 @@ func (x *Price) Reset() {
 	}
 }
 
-func (x *Price) String() string {
+func (x *Price) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1486,7 +1486,7 @@ func (x *Timestamp) Reset() {
 	}
 }
 
-func (x *Timestamp) String() string {
+func (x *Timestamp) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1535,7 +1535,7 @@ func (x *Party) Reset() {
 	}
 }
 
-func (x *Party) String() string {
+func (x *Party) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1588,7 +1588,7 @@ func (x *RiskFactor) Reset() {
 	}
 }
 
-func (x *RiskFactor) String() string {
+func (x *RiskFactor) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1654,7 +1654,7 @@ func (x *PeggedOrder) Reset() {
 	}
 }
 
-func (x *PeggedOrder) String() string {
+func (x *PeggedOrder) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1755,7 +1755,7 @@ func (x *Order) Reset() {
 	}
 }
 
-func (x *Order) String() string {
+func (x *Order) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1930,7 +1930,7 @@ func (x *OrderCancellationConfirmation) Reset() {
 	}
 }
 
-func (x *OrderCancellationConfirmation) String() string {
+func (x *OrderCancellationConfirmation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -1983,7 +1983,7 @@ func (x *OrderConfirmation) Reset() {
 	}
 }
 
-func (x *OrderConfirmation) String() string {
+func (x *OrderConfirmation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2054,7 +2054,7 @@ func (x *AuctionIndicativeState) Reset() {
 	}
 }
 
-func (x *AuctionIndicativeState) String() string {
+func (x *AuctionIndicativeState) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2161,7 +2161,7 @@ func (x *Trade) Reset() {
 	}
 }
 
-func (x *Trade) String() string {
+func (x *Trade) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2312,7 +2312,7 @@ func (x *Fee) Reset() {
 	}
 }
 
-func (x *Fee) String() string {
+func (x *Fee) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2374,7 +2374,7 @@ func (x *TradeSet) Reset() {
 	}
 }
 
-func (x *TradeSet) String() string {
+func (x *TradeSet) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2439,7 +2439,7 @@ func (x *Candle) Reset() {
 	}
 }
 
-func (x *Candle) String() string {
+func (x *Candle) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2542,7 +2542,7 @@ func (x *PriceLevel) Reset() {
 	}
 }
 
-func (x *PriceLevel) String() string {
+func (x *PriceLevel) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2611,7 +2611,7 @@ func (x *MarketDepth) Reset() {
 	}
 }
 
-func (x *MarketDepth) String() string {
+func (x *MarketDepth) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2687,7 +2687,7 @@ func (x *MarketDepthUpdate) Reset() {
 	}
 }
 
-func (x *MarketDepthUpdate) String() string {
+func (x *MarketDepthUpdate) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2770,7 +2770,7 @@ func (x *Position) Reset() {
 	}
 }
 
-func (x *Position) String() string {
+func (x *Position) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2863,7 +2863,7 @@ func (x *PositionTrade) Reset() {
 	}
 }
 
-func (x *PositionTrade) String() string {
+func (x *PositionTrade) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -2933,7 +2933,7 @@ func (x *Deposit) Reset() {
 	}
 }
 
-func (x *Deposit) String() string {
+func (x *Deposit) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3052,7 +3052,7 @@ func (x *Withdrawal) Reset() {
 	}
 }
 
-func (x *Withdrawal) String() string {
+func (x *Withdrawal) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3174,7 +3174,7 @@ func (x *WithdrawExt) Reset() {
 	}
 }
 
-func (x *WithdrawExt) String() string {
+func (x *WithdrawExt) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3241,7 +3241,7 @@ func (x *Erc20WithdrawExt) Reset() {
 	}
 }
 
-func (x *Erc20WithdrawExt) String() string {
+func (x *Erc20WithdrawExt) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3303,7 +3303,7 @@ func (x *Account) Reset() {
 	}
 }
 
-func (x *Account) String() string {
+func (x *Account) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3389,7 +3389,7 @@ func (x *FinancialAmount) Reset() {
 	}
 }
 
-func (x *FinancialAmount) String() string {
+func (x *FinancialAmount) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3451,7 +3451,7 @@ func (x *Transfer) Reset() {
 	}
 }
 
-func (x *Transfer) String() string {
+func (x *Transfer) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3531,7 +3531,7 @@ func (x *TransferRequest) Reset() {
 	}
 }
 
-func (x *TransferRequest) String() string {
+func (x *TransferRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3626,7 +3626,7 @@ func (x *LedgerEntry) Reset() {
 	}
 }
 
-func (x *LedgerEntry) String() string {
+func (x *LedgerEntry) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3712,7 +3712,7 @@ func (x *TransferBalance) Reset() {
 	}
 }
 
-func (x *TransferBalance) String() string {
+func (x *TransferBalance) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3770,7 +3770,7 @@ func (x *TransferResponse) Reset() {
 	}
 }
 
-func (x *TransferResponse) String() string {
+func (x *TransferResponse) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3841,7 +3841,7 @@ func (x *MarginLevels) Reset() {
 	}
 }
 
-func (x *MarginLevels) String() string {
+func (x *MarginLevels) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -3994,7 +3994,7 @@ func (x *MarketData) Reset() {
 	}
 }
 
-func (x *MarketData) String() string {
+func (x *MarketData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4222,7 +4222,7 @@ func (x *LiquidityProviderFeeShare) Reset() {
 	}
 }
 
-func (x *LiquidityProviderFeeShare) String() string {
+func (x *LiquidityProviderFeeShare) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4291,7 +4291,7 @@ func (x *PriceMonitoringBounds) Reset() {
 	}
 }
 
-func (x *PriceMonitoringBounds) String() string {
+func (x *PriceMonitoringBounds) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4365,7 +4365,7 @@ func (x *ErrorDetail) Reset() {
 	}
 }
 
-func (x *ErrorDetail) String() string {
+func (x *ErrorDetail) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4430,7 +4430,7 @@ func (x *NetworkParameter) Reset() {
 	}
 }
 
-func (x *NetworkParameter) String() string {
+func (x *NetworkParameter) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4502,7 +4502,7 @@ func (x *NetworkLimits) Reset() {
 	}
 }
 
-func (x *NetworkLimits) String() string {
+func (x *NetworkLimits) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4611,7 +4611,7 @@ func (x *LiquidityOrder) Reset() {
 	}
 }
 
-func (x *LiquidityOrder) String() string {
+func (x *LiquidityOrder) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4676,7 +4676,7 @@ func (x *LiquidityOrderReference) Reset() {
 	}
 }
 
-func (x *LiquidityOrderReference) String() string {
+func (x *LiquidityOrderReference) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4756,7 +4756,7 @@ func (x *LiquidityProvision) Reset() {
 	}
 }
 
-func (x *LiquidityProvision) String() string {
+func (x *LiquidityProvision) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4898,7 +4898,7 @@ func (x *EthereumConfig) Reset() {
 	}
 }
 
-func (x *EthereumConfig) String() string {
+func (x *EthereumConfig) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -4990,7 +4990,7 @@ func (x *EthereumContractConfig) Reset() {
 	}
 }
 
-func (x *EthereumContractConfig) String() string {
+func (x *EthereumContractConfig) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5057,7 +5057,7 @@ func (x *EpochTimestamps) Reset() {
 	}
 }
 
-func (x *EpochTimestamps) String() string {
+func (x *EpochTimestamps) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5139,7 +5139,7 @@ func (x *Epoch) Reset() {
 	}
 }
 
-func (x *Epoch) String() string {
+func (x *Epoch) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5210,7 +5210,7 @@ func (x *EpochParticipation) Reset() {
 	}
 }
 
-func (x *EpochParticipation) String() string {
+func (x *EpochParticipation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5283,7 +5283,7 @@ func (x *EpochData) Reset() {
 	}
 }
 
-func (x *EpochData) String() string {
+func (x *EpochData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5355,7 +5355,7 @@ func (x *RankingScore) Reset() {
 	}
 }
 
-func (x *RankingScore) String() string {
+func (x *RankingScore) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5448,7 +5448,7 @@ func (x *RewardScore) Reset() {
 	}
 }
 
-func (x *RewardScore) String() string {
+func (x *RewardScore) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5565,7 +5565,7 @@ func (x *Node) Reset() {
 	}
 }
 
-func (x *Node) String() string {
+func (x *Node) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5740,7 +5740,7 @@ func (x *NodeData) Reset() {
 	}
 }
 
-func (x *NodeData) String() string {
+func (x *NodeData) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5822,7 +5822,7 @@ func (x *Delegation) Reset() {
 	}
 }
 
-func (x *Delegation) String() string {
+func (x *Delegation) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5896,7 +5896,7 @@ func (x *Reward) Reset() {
 	}
 }
 
-func (x *Reward) String() string {
+func (x *Reward) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -5982,7 +5982,7 @@ func (x *RewardSummary) Reset() {
 	}
 }
 
-func (x *RewardSummary) String() string {
+func (x *RewardSummary) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6048,7 +6048,7 @@ func (x *StateValueProposal) Reset() {
 	}
 }
 
-func (x *StateValueProposal) String() string {
+func (x *StateValueProposal) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6111,7 +6111,7 @@ func (x *KeyValueBundle) Reset() {
 	}
 }
 
-func (x *KeyValueBundle) String() string {
+func (x *KeyValueBundle) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6176,7 +6176,7 @@ func (x *StateVarValue) Reset() {
 	}
 }
 
-func (x *StateVarValue) String() string {
+func (x *StateVarValue) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6266,7 +6266,7 @@ func (x *ScalarValue) Reset() {
 	}
 }
 
-func (x *ScalarValue) String() string {
+func (x *ScalarValue) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6313,7 +6313,7 @@ func (x *VectorValue) Reset() {
 	}
 }
 
-func (x *VectorValue) String() string {
+func (x *VectorValue) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6360,7 +6360,7 @@ func (x *MatrixValue) Reset() {
 	}
 }
 
-func (x *MatrixValue) String() string {
+func (x *MatrixValue) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
@@ -6407,7 +6407,7 @@ func (x *Uint64Value) Reset() {
 	}
 }
 
-func (x *Uint64Value) String() string {
+func (x *Uint64Value) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 

--- a/vega/wallet/v1/wallet.pb.go
+++ b/vega/wallet/v1/wallet.pb.go
@@ -63,7 +63,7 @@ func (x *SubmitTransactionRequest) Reset() {
 	}
 }
 
-func (x *SubmitTransactionRequest) String() string {
+func (x *SubmitTransactionRequest) NonDeterministicString() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 


### PR DESCRIPTION
**DO NOT MERGE** this is only used to track code calling non-deterministic `.String()` method, in the core.