### PR TITLE
fix: remove unnecessary semicolon from vega proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [](https://github.com/vegaprotocol/protos/pull/) -
 
 ### 🐛 Fixes
-- [](https://github.com/vegaprotocol/protos/pull/) -
+- [433](https://github.com/vegaprotocol/protos/pull/433) - remove unnecessary semicolon from vega proto
 
 
 ## 0.51.0

--- a/sources/data-node/api/v1/trading_data.proto
+++ b/sources/data-node/api/v1/trading_data.proto
@@ -1238,7 +1238,7 @@ message OracleSpecRequest {
 // A response for a oracle spec
 message OracleSpecResponse {
   // The withdrawal matching the identifier from the request
-  oracles.v1.OracleSpec oracle_spec = 1 ;
+  oracles.v1.OracleSpec oracle_spec = 1;
 }
 
 // A request to get a specific oracle spec by identifier

--- a/sources/vega/vega.proto
+++ b/sources/vega/vega.proto
@@ -1201,7 +1201,7 @@ message Node {
   // The amount the node has put up themselves
   string staked_by_operator = 7;
   // The amount of stake that has been delegated by token holders
-  string staked_by_delegates = 8;;
+  string staked_by_delegates = 8;
   // Total amount staked on node
   string staked_total = 9;
   // Max amount of (wanted) stake, is this a network param or a node param


### PR DESCRIPTION
I am using the BloomRPC client, and I am getting the following error when I am trying to import the data node v1 api:

```
illegal token ';' (/Users/daniel/www/vega/protos/sources/vega/vega.proto, line 1204)
```
<img width="370" alt="obraz" src="https://user-images.githubusercontent.com/1239637/169308421-bfb92dc4-475c-42a8-bb9f-189cbd2e1e6d.png">

